### PR TITLE
Correções LiquidBackgroundService/RabbitMqConsumer

### DIFF
--- a/src/Liquid.Messaging.RabbitMq/Liquid.Messaging.RabbitMq.csproj
+++ b/src/Liquid.Messaging.RabbitMq/Liquid.Messaging.RabbitMq.csproj
@@ -9,7 +9,7 @@
     <Copyright>Avanade 2019</Copyright>
     <PackageProjectUrl>https://github.com/Avanade/Liquid.Messaging</PackageProjectUrl>
     <PackageIcon>logo.png</PackageIcon>
-    <Version>2.0.0</Version>
+    <Version>2.0.1-preview-20220906-01</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>
       The Liquid.Messaging.RabbitMq provides producer and consumer patterns to allow the send and consumption of Messaging inside your microservice.

--- a/src/Liquid.Messaging.RabbitMq/RabbitMqConsumer.cs
+++ b/src/Liquid.Messaging.RabbitMq/RabbitMqConsumer.cs
@@ -25,7 +25,6 @@ namespace Liquid.Messaging.RabbitMq
         private IModel _channelModel;
         private readonly IRabbitMqFactory _factory;
         private readonly RabbitMqConsumerSettings _settings;
-        private ILogger<RabbitMqConsumer<TEntity>> _logger;
 
         ///<inheritdoc/>
         public event Func<ProcessMessageEventArgs<TEntity>, CancellationToken, Task> ProcessMessageAsync;
@@ -38,13 +37,11 @@ namespace Liquid.Messaging.RabbitMq
         /// </summary>
         /// <param name="factory">RabbitMq client factory.</param>
         /// <param name="settings">Configuration properties set.</param>
-        /// <param name="logger">Logger service instance.</param>
-        public RabbitMqConsumer(IRabbitMqFactory factory, RabbitMqConsumerSettings settings, ILogger<RabbitMqConsumer<TEntity>> logger)
+        public RabbitMqConsumer(IRabbitMqFactory factory, RabbitMqConsumerSettings settings)
         {
             _factory = factory ?? throw new ArgumentNullException(nameof(factory));
             _settings = settings ?? throw new ArgumentNullException(nameof(settings));
 
-            _logger = logger;
             _autoAck = _settings.AdvancedSettings?.AutoAck ?? true;
         }
 
@@ -53,7 +50,7 @@ namespace Liquid.Messaging.RabbitMq
         {
             if (ProcessMessageAsync is null)
             {
-                throw new NotImplementedException($"The {nameof(ProcessErrorAsync)} action must be added to class.");
+                throw new NotImplementedException($"The {nameof(ProcessMessageAsync)} action must be added to class.");
             }
 
             _channelModel = _factory.GetReceiver(_settings);
@@ -81,12 +78,12 @@ namespace Liquid.Messaging.RabbitMq
                     _channelModel.BasicAck(deliverEvent.DeliveryTag, false);
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 if (!_autoAck)
+                {
                     _channelModel.BasicNack(deliverEvent.DeliveryTag, false, true);
-
-                _logger.LogError(ex, ex.Message);
+                }
             }
         }
 

--- a/src/Liquid.Messaging/LiquidBackgroundService.cs
+++ b/src/Liquid.Messaging/LiquidBackgroundService.cs
@@ -1,6 +1,7 @@
 ﻿using Liquid.Messaging.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -54,14 +55,16 @@ namespace Liquid.Messaging
         /// </summary>
         /// <param name="args"></param>
         /// <param name="cancellationToken"></param>
-        public Task ProcessMessageAsync(ProcessMessageEventArgs<TEntity> args, CancellationToken cancellationToken)
+        public async Task ProcessMessageAsync(ProcessMessageEventArgs<TEntity> args, CancellationToken cancellationToken)
         {
+
             using (IServiceScope scope = _serviceProvider.CreateScope())
             {
                 var worker = scope.ServiceProvider.GetRequiredService<ILiquidWorker<TEntity>>();
 
-                return worker.ProcessMessageAsync(args, cancellationToken);
+                await worker.ProcessMessageAsync(args, cancellationToken);
             }
+
         }
     }
 }

--- a/test/Liquid.Messaging.RabbitMq.Tests/RabbitMqConsumerTest.cs
+++ b/test/Liquid.Messaging.RabbitMq.Tests/RabbitMqConsumerTest.cs
@@ -16,10 +16,9 @@ namespace Liquid.Messaging.RabbitMq.Tests
     public class RabbitMqConsumerTest : RabbitMqConsumer<MessageMock>
     {
         public static readonly IRabbitMqFactory _factory = Substitute.For<IRabbitMqFactory>();
-        public static readonly ILogger<RabbitMqConsumer<MessageMock>> _logger = Substitute.For<ILogger<RabbitMqConsumer<MessageMock>>>();
 
         public RabbitMqConsumerTest()
-            : base(_factory, new RabbitMqConsumerSettings(), _logger)
+            : base(_factory, new RabbitMqConsumerSettings())
         {
 
         }
@@ -62,26 +61,6 @@ namespace Liquid.Messaging.RabbitMq.Tests
             ProcessMessageAsync += ProcessMessageAsyncMock;
 
             await MessageHandler(message, new CancellationToken());
-        }
-
-        [Fact]
-        public void MessageHandler_WhenProcessExecutionFail_LogException()
-        {
-            var message = new BasicDeliverEventArgs();
-
-            var entity = new MessageMock() { TestMessageId = 2 };
-
-            message.Body = entity.ToJsonBytes();
-
-            var messageReceiver = Substitute.For<IModel>();
-            _factory.GetReceiver(Arg.Any<RabbitMqConsumerSettings>()).Returns(messageReceiver);
-
-            ProcessMessageAsync += ProcessMessageAsyncMock;
-
-            var task = MessageHandler(message, new CancellationToken());
-
-            _logger.Received(1);
-
         }
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously

--- a/test/Liquid.Messaging.RabbitMq.Tests/RabbitMqConsumerTest.cs
+++ b/test/Liquid.Messaging.RabbitMq.Tests/RabbitMqConsumerTest.cs
@@ -2,6 +2,7 @@
 using Liquid.Messaging.Exceptions;
 using Liquid.Messaging.RabbitMq.Settings;
 using Liquid.Messaging.RabbitMq.Tests.Mock;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
@@ -15,8 +16,10 @@ namespace Liquid.Messaging.RabbitMq.Tests
     public class RabbitMqConsumerTest : RabbitMqConsumer<MessageMock>
     {
         public static readonly IRabbitMqFactory _factory = Substitute.For<IRabbitMqFactory>();
+        public static readonly ILogger<RabbitMqConsumer<MessageMock>> _logger = Substitute.For<ILogger<RabbitMqConsumer<MessageMock>>>();
+
         public RabbitMqConsumerTest()
-            : base(_factory, new RabbitMqConsumerSettings())
+            : base(_factory, new RabbitMqConsumerSettings(), _logger)
         {
 
         }
@@ -62,7 +65,7 @@ namespace Liquid.Messaging.RabbitMq.Tests
         }
 
         [Fact]
-        public async Task MessageHandler_WhenProcessExecutionFail_ThrowException()
+        public void MessageHandler_WhenProcessExecutionFail_LogException()
         {
             var message = new BasicDeliverEventArgs();
 
@@ -77,7 +80,7 @@ namespace Liquid.Messaging.RabbitMq.Tests
 
             var task = MessageHandler(message, new CancellationToken());
 
-            await Assert.ThrowsAsync<MessagingConsumerException>(() => task);
+            _logger.Received(1);
 
         }
 


### PR DESCRIPTION
Adição de async/await no metodo ProcessMessageAsync
Correções RabbitMqConsumer, exceção sem tratamentos direto, fazendo a worker reiniciar, adição de log para estes casos.

resolve [issue114](https://github.com/Avanade/Liquid-Application-Framework/issues/114)