### PR TITLE
Releases/liquid.cache.redis v2.0.0

### DIFF
--- a/src/Liquid.Cache.Redis/Extensions/DependencyInjection/IServiceCollectionExtension.cs
+++ b/src/Liquid.Cache.Redis/Extensions/DependencyInjection/IServiceCollectionExtension.cs
@@ -1,4 +1,4 @@
-﻿using Liquid.Cache.DistributedCache.Extensions.DependencyInjection;
+﻿using Liquid.Cache.Extensions.DependencyInjection;
 using Liquid.Core.Implementations;
 using Microsoft.Extensions.Caching.StackExchangeRedis;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Liquid.Cache.Redis/Liquid.Cache.Redis.csproj
+++ b/src/Liquid.Cache.Redis/Liquid.Cache.Redis.csproj
@@ -21,6 +21,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="..\..\logo.png" Link="logo.png">
+      <PackagePath></PackagePath>
+      <Pack>True</Pack>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Liquid.Cache" Version="2.0.0-preview-2022090901-01" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.8" />
   </ItemGroup>

--- a/src/Liquid.Cache.Redis/Liquid.Cache.Redis.csproj
+++ b/src/Liquid.Cache.Redis/Liquid.Cache.Redis.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Liquid.Cache" Version="2.0.0-preview-2022090901-01" />
+    <PackageReference Include="Liquid.Cache" Version="2.0.0-preview-2022090901-02" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.8" />
   </ItemGroup>
 


### PR DESCRIPTION
fix logo and update Liquid.Cache reference version.