### PR TITLE
Releases/liquid.cache.sqlserver v2.0.0 preview

### DIFF
--- a/.github/workflows/liquid-ci-cd-cache-sqlserver.yml
+++ b/.github/workflows/liquid-ci-cd-cache-sqlserver.yml
@@ -1,0 +1,26 @@
+# CI & CD workflow
+name: CI/CD - Liquid.Cache.SqlServer component for Liquid Application Framework
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - 'src/Liquid.Cache.SqlServer/**'
+    
+  pull_request:
+    branches: [ main, releases/** ]
+    types: [opened, synchronize, reopened]
+    paths:
+    - 'src/Liquid.Cache.SqlServer/**'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  call-reusable-build-workflow:
+    uses: Avanade/Liquid-Application-Framework/.github/workflows/base-liquid-ci-and-cd.yml@main
+    with:
+      component_name: Liquid.Cache.SqlServer
+    secrets:
+      sonar_token: ${{ secrets.SONAR_TOKEN_CACHE_SQLSERVER }}
+      nuget_token: ${{ secrets.PUBLISH_TO_NUGET_ORG }}

--- a/Liquid.Cache.sln
+++ b/Liquid.Cache.sln
@@ -28,9 +28,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Liquid.Cache.Memory.Tests",
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NCache", "NCache", "{7F52BA22-BE38-497D-A02C-7FB3725ECC82}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Liquid.Cache.NCache", "src\Liquid.Cache.NCache\Liquid.Cache.NCache.csproj", "{B288A6CF-96FD-4EF9-BB09-ADBD04FCF751}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Liquid.Cache.NCache", "src\Liquid.Cache.NCache\Liquid.Cache.NCache.csproj", "{B288A6CF-96FD-4EF9-BB09-ADBD04FCF751}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Liquid.Cache.NCache.Tests", "test\Liquid.Cache.NCache.Tests\Liquid.Cache.NCache.Tests.csproj", "{5AE4C741-AC54-449F-BEE2-501036EE22E5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Liquid.Cache.NCache.Tests", "test\Liquid.Cache.NCache.Tests\Liquid.Cache.NCache.Tests.csproj", "{5AE4C741-AC54-449F-BEE2-501036EE22E5}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SqlServer", "SqlServer", "{E382C506-ECA9-4DD5-9F1B-587ABD126C38}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Liquid.Cache.SqlServer", "src\Liquid.Cache.SqlServer\Liquid.Cache.SqlServer.csproj", "{9FC090C1-866F-4566-B52D-25688C0B3063}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Liquid.Cache.SqlServer.Tests", "test\Liquid.Cache.SqlServer.Tests\Liquid.Cache.SqlServer.Tests.csproj", "{D4CC98D6-ACAF-4593-B41E-31D9E5C85F54}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -70,6 +76,14 @@ Global
 		{5AE4C741-AC54-449F-BEE2-501036EE22E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5AE4C741-AC54-449F-BEE2-501036EE22E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5AE4C741-AC54-449F-BEE2-501036EE22E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9FC090C1-866F-4566-B52D-25688C0B3063}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9FC090C1-866F-4566-B52D-25688C0B3063}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9FC090C1-866F-4566-B52D-25688C0B3063}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9FC090C1-866F-4566-B52D-25688C0B3063}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4CC98D6-ACAF-4593-B41E-31D9E5C85F54}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4CC98D6-ACAF-4593-B41E-31D9E5C85F54}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4CC98D6-ACAF-4593-B41E-31D9E5C85F54}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4CC98D6-ACAF-4593-B41E-31D9E5C85F54}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -81,6 +95,8 @@ Global
 		{983C0073-F73C-425D-A239-A8C5C1E2E5F9} = {3DEA6AB0-831F-4AE9-84BA-0D363C8629DA}
 		{B288A6CF-96FD-4EF9-BB09-ADBD04FCF751} = {7F52BA22-BE38-497D-A02C-7FB3725ECC82}
 		{5AE4C741-AC54-449F-BEE2-501036EE22E5} = {7F52BA22-BE38-497D-A02C-7FB3725ECC82}
+		{9FC090C1-866F-4566-B52D-25688C0B3063} = {E382C506-ECA9-4DD5-9F1B-587ABD126C38}
+		{D4CC98D6-ACAF-4593-B41E-31D9E5C85F54} = {E382C506-ECA9-4DD5-9F1B-587ABD126C38}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BC45FBB9-D2C3-4E3F-8668-5AA9146BBE4C}

--- a/src/Liquid.Cache.SqlServer/Extensions/DependencyInjection/IServiceCollectionExtension.cs
+++ b/src/Liquid.Cache.SqlServer/Extensions/DependencyInjection/IServiceCollectionExtension.cs
@@ -1,0 +1,30 @@
+﻿using Liquid.Cache.Extensions.DependencyInjection;
+using Liquid.Core.Implementations;
+using Microsoft.Extensions.Caching.SqlServer;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace Liquid.Cache.SqlServer.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// LiquidCache using SqlServer <see cref="IServiceCollection"/> extensions class.
+    /// </summary>
+    public static class IServiceCollectionExtension
+    {
+        /// <summary>
+        /// Registers <see cref="SqlServerCache"/> service and <see cref="LiquidCache"/> decorator,
+        /// with its <see cref="LiquidTelemetryInterceptor"/>.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="setupAction">An System.Action`1 to configure the provided
+        ///<see cref="SqlServerCacheOptions"/>.</param>
+        /// <param name="withTelemetry">Indicates if this method must register a <see cref="LiquidTelemetryInterceptor"/></param>
+        public static IServiceCollection AddLiquidSqlServerDistributedCache(this IServiceCollection services,
+            Action<SqlServerCacheOptions> setupAction, bool withTelemetry = true)
+        {
+            services.AddDistributedSqlServerCache(setupAction);
+
+            return services.AddLiquidDistributedCache(withTelemetry);
+        }
+    }
+}

--- a/src/Liquid.Cache.SqlServer/Liquid.Cache.SqlServer.csproj
+++ b/src/Liquid.Cache.SqlServer/Liquid.Cache.SqlServer.csproj
@@ -1,0 +1,37 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+     <PackageId>Liquid.Cache.SqlServer</PackageId>
+	  <Nullable>enable</Nullable>
+	  <PackageLicenseExpression>MIT</PackageLicenseExpression>
+	  <Authors>Avanade Brazil</Authors>
+	  <Company>Avanade Inc.</Company>
+	  <Product>Liquid Application Framework</Product>
+	  <Copyright>Avanade 2019</Copyright>
+	  <PackageProjectUrl>https://github.com/Avanade/Liquid-Application-Framework</PackageProjectUrl>
+	  <PackageIcon>logo.png</PackageIcon>
+	  <Version>2.0.0-preview-2022090901-01</Version>
+	  <GenerateDocumentationFile>true</GenerateDocumentationFile>
+	  <IsPackable>true</IsPackable>
+	  <DebugType>Full</DebugType>
+	  <Description>
+		  Distributed cache extension of Microsoft.Extensions.Caching.SqlServer.
+		  This component is part of Liquid Application Framework.
+	  </Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\logo.png" Link="logo.png">
+      <PackagePath></PackagePath>
+      <Pack>True</Pack>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Liquid.Cache" Version="2.0.0-preview-2022090901-02" />
+    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="6.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/test/Liquid.Cache.SqlServer.Tests/IServiceCollectionExtensionTest.cs
+++ b/test/Liquid.Cache.SqlServer.Tests/IServiceCollectionExtensionTest.cs
@@ -1,0 +1,62 @@
+using Liquid.Cache.SqlServer.Extensions.DependencyInjection;
+using Microsoft.Extensions.Caching.SqlServer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace Liquid.Cache.SqlServer.Tests
+{
+    public class IServiceCollectionExtensionTest
+    {
+        private IServiceCollection _sut;
+        private IConfiguration _configProvider = Substitute.For<IConfiguration>();
+        private IConfigurationSection _configurationSection = Substitute.For<IConfigurationSection>();
+
+        private void SetCollection()
+        {
+            _configProvider.GetSection(Arg.Any<string>()).Returns(_configurationSection);
+            _sut = new ServiceCollection();
+            _sut.AddSingleton(_configProvider);
+        }
+
+        [Fact]
+        public void AddLiquidSqlServerDistributedCache_WhenWithTelemetryTrue_GetServicesReturnLiqudCache()
+        {
+            SetCollection();
+            _sut.AddLogging();
+            _sut.AddLiquidSqlServerDistributedCache(options =>
+            {
+                options.ConnectionString = "DistCache_ConnectionString";
+                options.SchemaName = "dbo";
+                options.TableName = "TestCache";
+            }, true);
+
+            var provider = _sut.BuildServiceProvider();
+
+            Assert.NotNull(provider.GetService<ILiquidCache>());
+            Assert.NotNull(_sut.FirstOrDefault(x => x.ServiceType == typeof(ILiquidCache) && x.Lifetime == ServiceLifetime.Scoped));
+            Assert.NotNull(_sut.FirstOrDefault(x => x.ImplementationType == typeof(SqlServerCache)));
+
+        }
+
+        [Fact]
+        public void AddLiquidSqlServerDistributedCache_WhenWithTelemetryfalse_GetServicesReturnLiqudCache()
+        {
+            SetCollection();
+            _sut.AddLiquidSqlServerDistributedCache(options =>
+            {
+                options.ConnectionString = "DistCache_ConnectionString";
+                options.SchemaName = "dbo";
+                options.TableName = "TestCache";
+            }, false);
+
+            var provider = _sut.BuildServiceProvider();
+
+            Assert.NotNull(provider.GetService<ILiquidCache>());
+            Assert.NotNull(_sut.FirstOrDefault(x => x.ServiceType == typeof(ILiquidCache) && x.Lifetime == ServiceLifetime.Scoped));
+            Assert.NotNull(_sut.FirstOrDefault(x => x.ImplementationType == typeof(SqlServerCache)));
+
+        }
+    }
+}

--- a/test/Liquid.Cache.SqlServer.Tests/Liquid.Cache.SqlServer.Tests.csproj
+++ b/test/Liquid.Cache.SqlServer.Tests/Liquid.Cache.SqlServer.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Liquid.Cache.SqlServer\Liquid.Cache.SqlServer.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This implementation just extends  Microsoft.Extensions.Caching.SqlServer DI by including Liquid.Cache decorator registry.
Resolves https://github.com/Avanade/Liquid-Application-Framework/issues/144