### PR TITLE
Update versão do projeto Liquid.Core

### DIFF
--- a/src/Liquid.Core.Telemetry.ElasticApm/Implementations/LiquidElasticApmTelemetryBehavior.cs
+++ b/src/Liquid.Core.Telemetry.ElasticApm/Implementations/LiquidElasticApmTelemetryBehavior.cs
@@ -13,7 +13,7 @@ namespace Liquid.Core.Telemetry.ElasticApm.MediatR
     /// </summary>
     /// <typeparam name="TRequest">The type of request.</typeparam>
     /// <typeparam name="TResponse">Type of response object obtained upon return of request.</typeparam>
-    public sealed class LiquidElasticApmTelemetryBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    public sealed class LiquidElasticApmTelemetryBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : IRequest<TResponse>
     {
         private readonly ILogger<LiquidElasticApmTelemetryBehavior<TRequest, TResponse>> _logger;
 
@@ -37,7 +37,7 @@ namespace Liquid.Core.Telemetry.ElasticApm.MediatR
         /// <param name="cancellationToken">Notification about operation to be cancelled.</param>
         /// <param name="next">Mext operation to be performed.</param>
         /// <returns></returns>
-        public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+        public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
         {
             var methodInfo = next.GetMethodInfo();
 

--- a/src/Liquid.Core.Telemetry.ElasticApm/Liquid.Core.Telemetry.ElasticApm.csproj
+++ b/src/Liquid.Core.Telemetry.ElasticApm/Liquid.Core.Telemetry.ElasticApm.csproj
@@ -10,7 +10,7 @@
     <Copyright>Avanade 2021</Copyright>
     <PackageProjectUrl>https://github.com/Avanade/Liquid.Core</PackageProjectUrl>
     <PackageIcon>logo.png</PackageIcon>
-    <Version>2.0.0-preview-20211216-01</Version>
+    <Version>6.0.0-preview-20221201-01</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ProjectGuid>{AD354CF6-C132-4B5D-944D-0DFE21509781}</ProjectGuid>
     <IsPackable>true</IsPackable>

--- a/src/Liquid.Core.Telemetry.ElasticApm/Liquid.Core.Telemetry.ElasticApm.csproj
+++ b/src/Liquid.Core.Telemetry.ElasticApm/Liquid.Core.Telemetry.ElasticApm.csproj
@@ -19,9 +19,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.12.1" />
-    <PackageReference Include="Liquid.Core" Version="2.1.0" />
-    <PackageReference Include="MediatR" Version="9.0.0" />
+    <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.18.0" />
+    <PackageReference Include="Liquid.Core" Version="2.2.0-preview-20220901-01" />
+    <PackageReference Include="MediatR" Version="11.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Liquid.Core/Liquid.Core.csproj
+++ b/src/Liquid.Core/Liquid.Core.csproj
@@ -10,7 +10,7 @@
     <Copyright>Avanade 2019</Copyright>
     <PackageProjectUrl>https://github.com/Avanade/Liquid.Core</PackageProjectUrl>
     <PackageIcon>logo.png</PackageIcon>
-    <Version>2.2.0-preview-20220901-01</Version>
+    <Version>6.0.0-preview-20221201-01</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ProjectGuid>{C33A89FC-4F4D-4274-8D0F-29456BA8F76B}</ProjectGuid>
     <IsPackable>true</IsPackable>

--- a/test/Liquid.Core.Telemetry.ElasticApm.Tests/Liquid.Core.Telemetry.ElasticApm.Tests.csproj
+++ b/test/Liquid.Core.Telemetry.ElasticApm.Tests/Liquid.Core.Telemetry.ElasticApm.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -11,16 +11,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0-preview.5.21301.5" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Liquid.Core.Telemetry.ElasticApm.Tests/LiquidElasticApmTelemetryBehaviorTests.cs
+++ b/test/Liquid.Core.Telemetry.ElasticApm.Tests/LiquidElasticApmTelemetryBehaviorTests.cs
@@ -31,10 +31,10 @@ namespace Liquid.Core.Telemetry.ElasticApm.Tests
             var pipelineBehavior = new LiquidElasticApmTelemetryBehavior<RequestMock, ResponseMock>(_logger, _tracer); 
 
             // Act
-            await pipelineBehavior.Handle(new RequestMock(), CancellationToken.None, () => 
+            await pipelineBehavior.Handle(new RequestMock(), () => 
             { 
                 return handler.Handle(new RequestMock(), CancellationToken.None); 
-            });
+            }, CancellationToken.None);
 
             // Assert
             _logger.Received(2);
@@ -50,10 +50,10 @@ namespace Liquid.Core.Telemetry.ElasticApm.Tests
 
             // Act
             await Assert.ThrowsAsync<NotImplementedException>(() => 
-                pipelineBehavior.Handle(new RequestMock(), CancellationToken.None, () =>
+                pipelineBehavior.Handle(new RequestMock(), () =>
                 {
                     return handler.Handle(new RequestMock(), CancellationToken.None);
-                })
+                }, CancellationToken.None)
             );
 
             // Assert


### PR DESCRIPTION
Atualização da versão dos projetos alinhado com a versão corrente do .NET 6.0.

Foram feitos ajustes no projeto de Liquid.Core.Telemetry.ElasticApm para contemplar as atualizações dos pacotes, houve mudança de assinatura em método.

Também foram realizados ajustes nos testes unitários do projeto Liquid.Core.Telemetry.ElasticApm.Tests/LiquidElasticApmTelemetryBehaviorTests.cs porque houve modificação na assinatura do Handle LiquidElasticApmTelemetryBehavior.