### PR TITLE
Upgrading Liquid.WebApi.Http.Extensions.Crud references to Liquid 6

### DIFF
--- a/Liquid.WebApi.sln
+++ b/Liquid.WebApi.sln
@@ -11,11 +11,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Liquid.WebApi.Grpc.Tests", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{7B0BC311-679F-4D1F-BE49-DF3E49863792}"
 	ProjectSection(SolutionItems) = preProject
-		.github\workflows\liquid-ci-cd-grpc-cartridge.yml = .github\workflows\liquid-ci-cd-grpc-cartridge.yml
-		.github\workflows\liquid-ci-cd-http-cartridge.yml = .github\workflows\liquid-ci-cd-http-cartridge.yml
+		.github\workflows\liquid-ci-cd-http-extensions-crud.yml = .github\workflows\liquid-ci-cd-http-extensions-crud.yml
+		.github\workflows\liquid-ci-cd-http.yml = .github\workflows\liquid-ci-cd-http.yml
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Grcp", "Grcp", "{15BED263-E56A-45B2-A647-7D44500383E1}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Grpc", "Grpc", "{15BED263-E56A-45B2-A647-7D44500383E1}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Http", "Http", "{13C213E0-722A-4CD5-9209-21E12FDA0CA8}"
 EndProject

--- a/src/Liquid.WebApi.Http.Extensions.Crud/Liquid.WebApi.Http.Extensions.Crud.csproj
+++ b/src/Liquid.WebApi.Http.Extensions.Crud/Liquid.WebApi.Http.Extensions.Crud.csproj
@@ -8,8 +8,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Liquid.Domain.Extensions.Crud" Version="2.0.0-preview-20211105-01" />
-    <PackageReference Include="Liquid.WebApi.Http" Version="2.0.1" />
+    <PackageReference Include="Liquid.Domain.Extensions.Crud" Version="6.0.0-preview-20230201-02" />
+    <PackageReference Include="Liquid.WebApi.Http" Version="6.0.0-preview-20230517-01" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -22,7 +22,7 @@
     <Copyright>Avanade 2019</Copyright>
     <PackageProjectUrl>https://github.com/Avanade/Liquid.WebApi</PackageProjectUrl>
     <PackageIcon>logo.png</PackageIcon>
-    <Version>2.0.0-preview20211118-01</Version>
+    <Version>6.0.0-preview-20230517-01</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <DebugType>Full</DebugType>

--- a/test/Liquid.WebApi.Http.Extensions.Crud.Tests/Liquid.WebApi.Http.Extensions.Crud.Tests.csproj
+++ b/test/Liquid.WebApi.Http.Extensions.Crud.Tests/Liquid.WebApi.Http.Extensions.Crud.Tests.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This commit closes issue #130 