### PR TITLE
fix: Forward the 'token' parameter to the 'GetAsync' and 'SetAsync'  methods.

### DIFF
--- a/src/Liquid.Cache/Liquid.Cache.csproj
+++ b/src/Liquid.Cache/Liquid.Cache.csproj
@@ -10,7 +10,7 @@
     <Copyright>Avanade 2019</Copyright>
     <PackageProjectUrl>https://github.com/Avanade/Liquid-Application-Framework</PackageProjectUrl>
     <PackageIcon>logo.png</PackageIcon>
-    <Version>6.0.0-preview-20231130-01</Version>
+    <Version>6.0.0-preview-20231130-02</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <DebugType>Full</DebugType>

--- a/src/Liquid.Cache/LiquidCache.cs
+++ b/src/Liquid.Cache/LiquidCache.cs
@@ -79,7 +79,7 @@ namespace Liquid.Cache
         ///<inheritdoc/>
         public async Task<T> GetAsync<T>(string key, CancellationToken token = default)
         {
-            var response = await _distributedCache.GetAsync(key);
+            var response = await _distributedCache.GetAsync(key, token);
             return response.ParseJson<T>();
         }
 
@@ -92,7 +92,7 @@ namespace Liquid.Cache
         ///<inheritdoc/>
         public async Task SetAsync<T>(string key, T value, DistributedCacheEntryOptions options, CancellationToken token = default)
         {
-            await _distributedCache.SetAsync(key, value.ToJsonBytes(), options);
+            await _distributedCache.SetAsync(key, value.ToJsonBytes(), options, token);
         }
     }
 }


### PR DESCRIPTION
resolve #179 