### PR TITLE
Fix Azure Storage Adapter

### DIFF
--- a/Liquid.WebApi.sln
+++ b/Liquid.WebApi.sln
@@ -5,17 +5,11 @@ VisualStudioVersion = 17.0.31612.314
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Liquid.WebApi.Http", "src\Liquid.WebApi.Http\Liquid.WebApi.Http.csproj", "{25D05D84-4DFB-4F3D-92A2-B06DFA244BA4}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Liquid.WebApi.Grpc", "src\Liquid.WebApi.Grpc\Liquid.WebApi.Grpc.csproj", "{7806419C-7191-4D7A-BD52-8E705553ABEB}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Liquid.WebApi.Grpc.Tests", "test\Liquid.WebApi.Grpc.Tests\Liquid.WebApi.Grpc.Tests.csproj", "{3B8464A5-3795-464E-A3B2-D2851C9E38DC}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{7B0BC311-679F-4D1F-BE49-DF3E49863792}"
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\liquid-ci-cd-http-extensions-crud.yml = .github\workflows\liquid-ci-cd-http-extensions-crud.yml
 		.github\workflows\liquid-ci-cd-http.yml = .github\workflows\liquid-ci-cd-http.yml
 	EndProjectSection
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Grpc", "Grpc", "{15BED263-E56A-45B2-A647-7D44500383E1}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Http", "Http", "{13C213E0-722A-4CD5-9209-21E12FDA0CA8}"
 EndProject
@@ -35,14 +29,6 @@ Global
 		{25D05D84-4DFB-4F3D-92A2-B06DFA244BA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{25D05D84-4DFB-4F3D-92A2-B06DFA244BA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{25D05D84-4DFB-4F3D-92A2-B06DFA244BA4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7806419C-7191-4D7A-BD52-8E705553ABEB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7806419C-7191-4D7A-BD52-8E705553ABEB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7806419C-7191-4D7A-BD52-8E705553ABEB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7806419C-7191-4D7A-BD52-8E705553ABEB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3B8464A5-3795-464E-A3B2-D2851C9E38DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3B8464A5-3795-464E-A3B2-D2851C9E38DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3B8464A5-3795-464E-A3B2-D2851C9E38DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3B8464A5-3795-464E-A3B2-D2851C9E38DC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{39DDC514-44CD-43BE-9E5B-C3B86665895E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{39DDC514-44CD-43BE-9E5B-C3B86665895E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{39DDC514-44CD-43BE-9E5B-C3B86665895E}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -61,8 +47,6 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{25D05D84-4DFB-4F3D-92A2-B06DFA244BA4} = {13C213E0-722A-4CD5-9209-21E12FDA0CA8}
-		{7806419C-7191-4D7A-BD52-8E705553ABEB} = {15BED263-E56A-45B2-A647-7D44500383E1}
-		{3B8464A5-3795-464E-A3B2-D2851C9E38DC} = {15BED263-E56A-45B2-A647-7D44500383E1}
 		{39DDC514-44CD-43BE-9E5B-C3B86665895E} = {13C213E0-722A-4CD5-9209-21E12FDA0CA8}
 		{52C452EC-7C53-4177-A0C5-8CCFC6C0D76F} = {13C213E0-722A-4CD5-9209-21E12FDA0CA8}
 		{B1629220-240B-4C02-80BE-655F093F86D8} = {13C213E0-722A-4CD5-9209-21E12FDA0CA8}

--- a/src/Liquid.Adapter.AzureStorage/BlobClientFactory.cs
+++ b/src/Liquid.Adapter.AzureStorage/BlobClientFactory.cs
@@ -24,21 +24,17 @@ namespace Liquid.Adapter.AzureStorage
         }
 
         ///<inheritdoc/>
-        public List<BlobContainerClient> SetContainerClients()
+        public void SetContainerClients()
         {
             if(_options.Containers.Count  == 0)
-                throw new ArgumentNullException(nameof(_options));
-
-            var clients = new List<BlobContainerClient>();           
+                throw new ArgumentNullException(nameof(_options));        
 
             foreach(var container in _options.Containers)
             {
                 var client = new BlobContainerClient(container.ConnectionString,container.ContainerName);
 
-                clients.Add(client);
+                _clients.Add(client);
             }
-
-            return clients;
         }
 
         ///<inheritdoc/>

--- a/src/Liquid.Adapter.AzureStorage/BlobStorageAdapter.cs
+++ b/src/Liquid.Adapter.AzureStorage/BlobStorageAdapter.cs
@@ -60,7 +60,7 @@ namespace Liquid.Adapter.AzureStorage
 
                 var item = new LiquidBlob
                 {
-                    Blob = Encoding.UTF8.GetString(blob.Value.Content.ToArray()),
+                    Blob = blob.Value.Content.ToArray(),
                     Name = blobItem.Name
                 };
                 results.Add(item);
@@ -98,7 +98,7 @@ namespace Liquid.Adapter.AzureStorage
                 var blob = await blockBlob.DownloadContentAsync();
                 var item = new LiquidBlob
                 {
-                    Blob = Encoding.UTF8.GetString(blob.Value.Content.ToArray()),
+                    Blob = blob.Value.Content.ToArray(),
                     Tags = blockBlob.GetTags().Value.Tags,
                     Name = blobItem.BlobName
                 };
@@ -108,7 +108,7 @@ namespace Liquid.Adapter.AzureStorage
         }
 
         ///<inheritdoc/>
-        public async Task UploadBlob(string data, string name, string containerName, IDictionary<string, string>? tags = null)
+        public async Task UploadBlob(byte[] data, string name, string containerName, IDictionary<string, string>? tags = null)
         {
             var client = _factory.GetContainerClient(containerName);
 
@@ -118,7 +118,7 @@ namespace Liquid.Adapter.AzureStorage
             {
                 Tags = tags
             };
-            await blockBlob.UploadAsync(new MemoryStream(Encoding.UTF8.GetBytes(data)), options);
+            await blockBlob.UploadAsync(new MemoryStream(data), options);
         }
 
         ///<inheritdoc/>
@@ -130,7 +130,7 @@ namespace Liquid.Adapter.AzureStorage
             var blob = await blockBlob.DownloadContentAsync();
             var item = new LiquidBlob
             {
-                Blob = Encoding.UTF8.GetString(blob.Value.Content.ToArray()),
+                Blob = blob.Value.Content.ToArray(),
                 Tags = blockBlob.GetTags().Value.Tags,
                 Name = blobName
             };

--- a/src/Liquid.Adapter.AzureStorage/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Liquid.Adapter.AzureStorage/Extensions/IServiceCollectionExtensions.cs
@@ -26,9 +26,9 @@ namespace Liquid.Adapter.AzureStorage.Extensions
                 configuration.GetSection(configSection).Bind(settings);
             });
 
-            services.AddTransient<IBlobClientFactory, BlobClientFactory>();
+            services.AddSingleton<IBlobClientFactory, BlobClientFactory>();
 
-            services.AddSingleton<ILiquidBlobStorageAdapter, BlobStorageAdapter>();
+            services.AddScoped<ILiquidBlobStorageAdapter, BlobStorageAdapter>();
 
             return services;
         }

--- a/src/Liquid.Adapter.AzureStorage/IBlobClientFactory.cs
+++ b/src/Liquid.Adapter.AzureStorage/IBlobClientFactory.cs
@@ -17,7 +17,7 @@ namespace Liquid.Adapter.AzureStorage
         /// for each container on the <see cref="StorageSettings"/> and 
         /// add to <see cref="Clients"/>.
         /// </summary>
-        List<BlobContainerClient> SetContainerClients();
+        void SetContainerClients();
 
         /// <summary>
         /// Get an instance of <see cref="BlobContainerClient"/>

--- a/src/Liquid.Adapter.AzureStorage/ILiquidBlobStorageAdapter.cs
+++ b/src/Liquid.Adapter.AzureStorage/ILiquidBlobStorageAdapter.cs
@@ -14,7 +14,7 @@ namespace Liquid.Adapter.AzureStorage
         /// <param name="name">Blob path.</param>
         /// <param name="containerName">Blob container name.</param>
         /// <param name="tags">Blob list of tags.</param>
-        Task UploadBlob(string data, string name, string containerName, IDictionary<string, string>? tags = null);
+        Task UploadBlob(byte[] data, string name, string containerName, IDictionary<string, string>? tags = null);
 
         /// <summary>
         /// Remove blob by id.

--- a/src/Liquid.Adapter.AzureStorage/Liquid.Adapter.AzureStorage.csproj
+++ b/src/Liquid.Adapter.AzureStorage/Liquid.Adapter.AzureStorage.csproj
@@ -8,7 +8,7 @@
 	  <Company>Avanade Inc.</Company>
 	  <Product>Liquid - Modern Application Framework</Product>
 	  <Copyright>Avanade 2019</Copyright>
-	  <Version>6.0.0-preview-20221201-01</Version>
+	  <Version>6.0.0-preview-20221201-02</Version>
 	  <GenerateDocumentationFile>true</GenerateDocumentationFile>
 	  <IsPackable>true</IsPackable>
 	  <Description>

--- a/src/Liquid.Adapter.AzureStorage/LiquidBlob.cs
+++ b/src/Liquid.Adapter.AzureStorage/LiquidBlob.cs
@@ -16,7 +16,7 @@ namespace Liquid.Adapter.AzureStorage
         /// <summary>
         /// Conteúdo do blob.
         /// </summary>
-        public string? Blob { get; set; }
+        public byte[]? Blob { get; set; }
 
         /// <summary>
         /// Nome do arquivo no Storage.

--- a/src/Liquid.WebApi.Http.Extensions.Crud/Liquid.WebApi.Http.Extensions.Crud.csproj
+++ b/src/Liquid.WebApi.Http.Extensions.Crud/Liquid.WebApi.Http.Extensions.Crud.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PackageId>Liquid.WebApi.Http.Extensions.Crud</PackageId>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>Avanade Brazil</Authors>
@@ -22,7 +22,7 @@
     <Copyright>Avanade 2019</Copyright>
     <PackageProjectUrl>https://github.com/Avanade/Liquid.WebApi</PackageProjectUrl>
     <PackageIcon>logo.png</PackageIcon>
-    <Version>6.0.0-preview-20230519-01</Version>
+    <Version>6.0.0-preview-20231130-01</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <DebugType>Full</DebugType>

--- a/src/Liquid.WebApi.Http/Liquid.WebApi.Http.csproj
+++ b/src/Liquid.WebApi.Http/Liquid.WebApi.Http.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PackageId>Liquid.WebApi.Http</PackageId>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Authors>Avanade Brazil</Authors>
@@ -10,7 +10,7 @@
     <Copyright>Avanade 2019</Copyright>
     <PackageProjectUrl>https://github.com/Avanade/Liquid.WebApi</PackageProjectUrl>
     <PackageIcon>logo.png</PackageIcon>
-    <Version>6.0.0-preview-20230517-01</Version>
+    <Version>6.0.0-preview-20231130-01</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <DebugType>Full</DebugType>

--- a/src/Liquid.WebApi.Http/Settings/SwaggerSettings.cs
+++ b/src/Liquid.WebApi.Http/Settings/SwaggerSettings.cs
@@ -1,5 +1,5 @@
 ﻿using Liquid.Core.Attributes;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Liquid.WebApi.Http.Settings
@@ -17,7 +17,7 @@ namespace Liquid.WebApi.Http.Settings
         /// <value>
         /// The name.
         /// </value>
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
 
         /// <summary>
@@ -26,7 +26,7 @@ namespace Liquid.WebApi.Http.Settings
         /// <value>
         /// The host.
         /// </value>
-        [JsonProperty("host")]
+        [JsonPropertyName("host")]
         public string Host { get; set; }
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace Liquid.WebApi.Http.Settings
         /// <value>
         /// Schemes.
         /// </value>
-        [JsonProperty("schemes")]
+        [JsonPropertyName("schemes")]
         public string[] Schemes { get; set; }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace Liquid.WebApi.Http.Settings
         /// <value>
         /// The title.
         /// </value>
-        [JsonProperty("title")]
+        [JsonPropertyName("title")]
         public string Title { get; set; }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace Liquid.WebApi.Http.Settings
         /// <value>
         /// The version.
         /// </value>
-        [JsonProperty("version")]
+        [JsonPropertyName("version")]
         public string Version { get; set; }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Liquid.WebApi.Http.Settings
         /// <value>
         /// The description.
         /// </value>
-        [JsonProperty("description")]
+        [JsonPropertyName("description")]
         public string Description { get; set; }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace Liquid.WebApi.Http.Settings
         /// <value>
         /// The swagger endpoint.
         /// </value>
-        [JsonProperty("endpoint")]
+        [JsonPropertyName("endpoint")]
         public SwaggerEndpoint SwaggerEndpoint { get; set; }
     }
 
@@ -87,7 +87,7 @@ namespace Liquid.WebApi.Http.Settings
         /// <value>
         /// The URL.
         /// </value>
-        [JsonProperty("url")]
+        [JsonPropertyName("url")]
         public string Url { get; set; }
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace Liquid.WebApi.Http.Settings
         /// <value>
         /// The name.
         /// </value>
-        [JsonProperty("name")]
+        [JsonPropertyName("name")]
         public string Name { get; set; }
     }
 }


### PR DESCRIPTION
fix: change body property type of LiquidBlob to byte[] in order to work with more types of blob (images, files etc). Also fixes dependency injection od BlobClientFactory and it's method SetContainer Client.