### PR TITLE
feat: Refactor LiquidChatMessage and update project references

### DIFF
--- a/src/Liquid.Core/GenAi/Entities/LiquidChatMessage.cs
+++ b/src/Liquid.Core/GenAi/Entities/LiquidChatMessage.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using Liquid.Core.GenAi.Enums;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Liquid.Core.GenAi.Entities
 {
@@ -11,11 +14,80 @@ namespace Liquid.Core.GenAi.Entities
         /// <summary>
         /// The chat role associated with this message.
         /// </summary>
-        public string Role { get; set; }
+        public LiquidMessageRole Role { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LiquidChatMessage"/> class with the specified role.
+        /// </summary>
+        /// <param name="role">The role associated with the chat message. This value cannot be null or empty.</param>
+        public LiquidChatMessage(LiquidMessageRole role)
+        {
+            Role = role;
+        }
 
         /// <summary>
         /// The contents of the message.
         /// </summary>
-        public LiquidChatContent[] Content { get; set; }
+        public LiquidChatContent[] Content { get; set; } = Array.Empty<LiquidChatContent>();
+
+
+        /// <summary>
+        /// Adds a text content item to the current collection of chat contents.
+        /// </summary>
+        /// <remarks>This method appends the specified text as a new content item to the existing
+        /// collection. If the collection is initially null, it initializes the collection with the new content
+        /// item.</remarks>
+        /// <param name="text">The text content to add. Cannot be null, empty, or consist solely of whitespace.</param>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="text"/> is null, empty, or consists only of whitespace.</exception>
+        public void AddContent(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                throw new ArgumentException("Text content cannot be null or empty.", nameof(text));
+            }
+            var content = new LiquidChatContent
+            {
+                Kind = LiquidContentKind.Text,
+                Text = text
+            };
+            if (Content == null)
+            {
+                Content = new[] { content };
+            }
+            else
+            {
+                var contentList = new List<LiquidChatContent>(Content) { content };
+                Content = contentList.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Adds an image content to the current collection of chat contents.
+        /// </summary>
+        /// <remarks>If the content collection is initially empty, this method initializes it with the new
+        /// image content. Otherwise, it appends the image content to the existing collection.</remarks>
+        /// <param name="imageUri">The URI of the image to be added. Cannot be <see langword="null"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="imageUri"/> is <see langword="null"/>.</exception>
+        public void AddContent(Uri imageUri)
+        {
+            if (imageUri == null)
+            {
+                throw new ArgumentNullException(nameof(imageUri), "Image URI cannot be null.");
+            }
+            var content = new LiquidChatContent
+            {
+                Kind = LiquidContentKind.Image,
+                ImageUri = imageUri
+            };
+            if (Content == null)
+            {
+                Content = new[] { content };
+            }
+            else
+            {
+                var contentList = new List<LiquidChatContent>(Content) { content };
+                Content = contentList.ToArray();
+            }
+        }
     }
 }

--- a/src/Liquid.Core/GenAi/Entities/LiquidChatMessages.cs
+++ b/src/Liquid.Core/GenAi/Entities/LiquidChatMessages.cs
@@ -13,5 +13,20 @@ namespace Liquid.Core.GenAi.Entities
         /// The collection of context messages associated with a chat completions request.
         /// </summary>
         public List<LiquidChatMessage> Messages { get; set; } = new List<LiquidChatMessage>();
+
+        /// <summary>
+        /// Adds a message to the collection of chat messages.
+        /// </summary>
+        /// <param name="message">The chat message to add. Cannot be <see langword="null"/>.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="message"/> is <see langword="null"/>.</exception>
+        public void AddMessage(LiquidChatMessage message)
+        {
+            if (message == null)
+            {
+                throw new System.ArgumentNullException(nameof(message), "Message cannot be null");
+            }
+            Messages.Add(message);
+        }
+
     }
 }

--- a/src/Liquid.Core/GenAi/Enums/LiquidMessageRole.cs
+++ b/src/Liquid.Core/GenAi/Enums/LiquidMessageRole.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Liquid.Core.GenAi.Enums
+{
+    /// <summary>
+    /// Specifies the role of a participant in a message exchange, such as a user, assistant, or system.
+    /// </summary>
+    public enum LiquidMessageRole
+    {
+        /// <summary>
+        /// The user role, typically representing the end user or client.
+        /// </summary>
+        User,
+        /// <summary>
+        /// The assistant role, typically representing the AI or system responding to the user.
+        /// </summary>
+        Assistant,
+        /// <summary>
+        /// The system role, typically used for system-level messages or instructions.
+        /// </summary>
+        System
+    }
+}

--- a/src/Liquid.Core/Liquid.Core.csproj
+++ b/src/Liquid.Core/Liquid.Core.csproj
@@ -10,7 +10,7 @@
     <Copyright>Avanade 2019</Copyright>
     <PackageProjectUrl>https://github.com/Avanade/Liquid-Application-Framework</PackageProjectUrl>
     <PackageIcon>logo.png</PackageIcon>
-    <Version>8.0.0</Version>
+    <Version>8.1.0</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ProjectGuid>{C33A89FC-4F4D-4274-8D0F-29456BA8F76B}</ProjectGuid>
     <IsPackable>true</IsPackable>

--- a/src/Liquid.GenAi.OpenAi/Liquid.GenAi.OpenAi.csproj
+++ b/src/Liquid.GenAi.OpenAi/Liquid.GenAi.OpenAi.csproj
@@ -32,8 +32,11 @@
 	
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageReference Include="Liquid.Core" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+  </ItemGroup>
+	
+  <ItemGroup>
+    <ProjectReference Include="..\Liquid.Core\Liquid.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Liquid.GenAi.OpenAi/OpenAiAdapter.cs
+++ b/src/Liquid.GenAi.OpenAi/OpenAiAdapter.cs
@@ -150,15 +150,15 @@ namespace Liquid.GenAi.OpenAi
         private static ChatMessage MapChatRequestMessage(LiquidChatMessage message)
         {
             ChatMessage? chatRequestMessage = null;
-            switch (message.Role.ToLower())
+            switch (message.Role)
             {
-                case "system":
+                case LiquidMessageRole.System:
                     chatRequestMessage = new SystemChatMessage(CreateContent(message));
                     break;
-                case "assistant":
+                case LiquidMessageRole.Assistant:
                     chatRequestMessage = new AssistantChatMessage(CreateContent(message));
                     break;
-                case "user":
+                case LiquidMessageRole.User:
                     chatRequestMessage = new UserChatMessage(CreateContent(message));
                     break;
                 default:


### PR DESCRIPTION
- Changed `Role` property in `LiquidChatMessage` to use the new `LiquidMessageRole` enum for better structure.
- Added constructor for `LiquidChatMessage` and initialized `Content` to an empty array by default.
- Introduced `AddContent(string text)` and `AddContent(Uri imageUri)` methods for adding content with validation.
- Added `AddMessage(LiquidChatMessage message)` method in `LiquidChatMessages` to ensure null messages are not added.
- Updated project version in `Liquid.Core.csproj` from `8.0.0` to `8.1.0`.
- Changed `Liquid.Core` reference in `Liquid.GenAi.OpenAi.csproj` from a package reference to a project reference.
- Updated `MapChatRequestMessage` method to use the new `LiquidMessageRole` enum.
- Created `LiquidMessageRole.cs` to define the `LiquidMessageRole` enum for message participant roles.