### PR TITLE
fix: Update version and enhance chat completion handling

### DIFF
--- a/src/Liquid.GenAi.OpenAi/Liquid.GenAi.OpenAi.csproj
+++ b/src/Liquid.GenAi.OpenAi/Liquid.GenAi.OpenAi.csproj
@@ -13,7 +13,7 @@
 	  <Copyright>Avanade 2019</Copyright>
 	  <PackageProjectUrl>https://github.com/Avanade/Liquid-Application-Framework</PackageProjectUrl>
 	  <PackageIcon>logo.png</PackageIcon>
-	  <Version>8.1.0</Version>
+	  <Version>8.1.1</Version>
 	  <GenerateDocumentationFile>true</GenerateDocumentationFile>
 	  <IsPackable>true</IsPackable>
 	  <DebugType>Full</DebugType>
@@ -31,7 +31,7 @@
 	</ItemGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+	  <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0-beta.2" />
     <PackageReference Include="Liquid.Core" Version="8.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
   </ItemGroup>

--- a/src/Liquid.GenAi.OpenAi/OpenAiAdapter.cs
+++ b/src/Liquid.GenAi.OpenAi/OpenAiAdapter.cs
@@ -85,9 +85,7 @@ namespace Liquid.GenAi.OpenAi
 
             messages.Messages.ForEach(m => requestMessages.Add(MapChatRequestMessage(m)));
 
-            var option = MapChatCompletionOptions(settings);
-
-            var responseWithoutStream = await client.CompleteChatAsync(requestMessages, option);
+            var option = MapChatCompletionOptions(settings);           
 
             if (functions != null)
             {
@@ -102,7 +100,12 @@ namespace Liquid.GenAi.OpenAi
                 }
             }
 
-            var response = responseWithoutStream.Value.Content[0].Text;
+            var responseWithoutStream = await client.CompleteChatAsync(requestMessages, option);
+
+
+            var response = responseWithoutStream.Value.FinishReason != ChatFinishReason.ToolCalls ?
+                responseWithoutStream.Value.Content[0].Text :
+                responseWithoutStream.Value.ToolCalls[0].FunctionArguments.ToString();
 
             var result = new ChatCompletionResult()
             {


### PR DESCRIPTION
- Bump version in `Liquid.GenAi.OpenAi.csproj` from 8.1.0 to 8.1.1.
- Update `Azure.AI.OpenAI` package reference to version 2.1.0-beta.2.
- Modify `OpenAiAdapter.cs` to include function tools in chat options.
- Improve response handling to differentiate between tool call results.